### PR TITLE
feat: add utility for parsing .gcloudignore files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     - uses: 'actions/setup-node@v2'
       with:
-        node-version: '12.x'
+        node-version: '16.x'
 
     - name: 'npm build'
       run: 'npm ci && npm run build && npm run docs'
@@ -53,7 +53,7 @@ jobs:
 
     - uses: 'actions/setup-node@v2'
       with:
-        node-version: '12.x'
+        node-version: '16.x'
 
     - name: 'npm build'
       run: 'npm ci && npm run build'

--- a/dist/ignore.d.ts
+++ b/dist/ignore.d.ts
@@ -1,0 +1,10 @@
+/**
+ * parseGcloudIgnore parses a gcloud ignore at the given filepath. It follows
+ * the parsing rules defined at
+ * https://cloud.google.com/sdk/gcloud/reference/topic/gcloudignore, including
+ * parsing any included files.
+ *
+ * @param pth Path to the gcloudignore file.
+ * @return Ordered list of strings from the various ignore files.
+ */
+export declare function parseGcloudIgnore(pth: string): Promise<string[]>;

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -11,6 +11,7 @@
 - [encoding](modules/encoding.md)
 - [errors](modules/errors.md)
 - [fs](modules/fs.md)
+- [ignore](modules/ignore.md)
 - [index](modules/index.md)
 - [kv](modules/kv.md)
 - [random](modules/random.md)

--- a/docs/modules/ignore.md
+++ b/docs/modules/ignore.md
@@ -1,0 +1,36 @@
+[@google-github-actions/actions-utils](../README.md) / [Exports](../modules.md) / ignore
+
+# Module: ignore
+
+## Table of contents
+
+### Functions
+
+- [parseGcloudIgnore](ignore.md#parsegcloudignore)
+
+## Functions
+
+### parseGcloudIgnore
+
+▸ **parseGcloudIgnore**(`pth`): `Promise`<`string`[]\>
+
+parseGcloudIgnore parses a gcloud ignore at the given filepath. It follows
+the parsing rules defined at
+https://cloud.google.com/sdk/gcloud/reference/topic/gcloudignore, including
+parsing any included files.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `pth` | `string` | Path to the gcloudignore file. |
+
+#### Returns
+
+`Promise`<`string`[]\>
+
+Ordered list of strings from the various ignore files.
+
+#### Defined in
+
+[ignore.ts:31](https://github.com/google-github-actions/actions-utils/blob/main/src/ignore.ts#L31)

--- a/src/ignore.ts
+++ b/src/ignore.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { promises as fs } from 'fs';
+import { dirname, join as pathjoin } from 'path';
+
+import { errorMessage } from './errors';
+
+/**
+ * parseGcloudIgnore parses a gcloud ignore at the given filepath. It follows
+ * the parsing rules defined at
+ * https://cloud.google.com/sdk/gcloud/reference/topic/gcloudignore, including
+ * parsing any included files.
+ *
+ * @param pth Path to the gcloudignore file.
+ * @return Ordered list of strings from the various ignore files.
+ */
+export async function parseGcloudIgnore(pth: string): Promise<string[]> {
+  const parentDir = dirname(pth);
+
+  let ignoreContents: string[] = [];
+  try {
+    ignoreContents = (await fs.readFile(pth, { encoding: 'utf-8' }))
+      .toString()
+      .split(/\r?\n/)
+      .filter(shouldKeepIgnoreLine)
+      .map((line) => line.trim());
+  } catch (err) {
+    const msg = errorMessage(err);
+    if (!msg.toUpperCase().includes('ENOENT')) {
+      throw err;
+    }
+  }
+
+  // Iterate through each line and parse any includes.
+  for (let i = 0; i < ignoreContents.length; i++) {
+    const line = ignoreContents[i];
+    if (line.startsWith('#!include:')) {
+      const includeName = line.substring(10).trim();
+
+      const includePth = pathjoin(parentDir, includeName);
+      const subIgnoreContents = (await fs.readFile(includePth, { encoding: 'utf-8' }))
+        .toString()
+        .split(/\r?\n/)
+        .filter(shouldKeepIgnoreLine)
+        .map((line) => line.trim());
+
+      ignoreContents.splice(i, 1, ...subIgnoreContents);
+      i += subIgnoreContents.length;
+    }
+  }
+
+  return ignoreContents;
+}
+
+/**
+ * shouldKeepIgnoreLine is a helper that returns true if the given line is not
+ * blank or a comment.
+ *
+ * @param line The line to check.
+ * @return boolean
+ */
+function shouldKeepIgnoreLine(line: string): boolean {
+  const trimmed = (line || '').trim();
+  if (trimmed === '') {
+    return false;
+  }
+
+  if (trimmed.startsWith('#') && !trimmed.startsWith('#!')) {
+    return false;
+  }
+
+  return true;
+}

--- a/tests/ignore.test.ts
+++ b/tests/ignore.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'mocha';
+import { expect } from 'chai';
+
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join as pathjoin } from 'path';
+
+import { errorMessage } from '../src/errors';
+import { writeSecureFile } from '../src/fs';
+import { randomFilepath, randomFilename } from '../src/random';
+
+import { parseGcloudIgnore } from '../src/ignore';
+
+describe('ignore', () => {
+  describe('#parseGcloudIgnore', () => {
+    const cases: {
+      only?: boolean;
+      name: string;
+      contents?: string;
+      extraContents?: string;
+      expected: string[];
+    }[] = [
+      {
+        name: 'non-existent file',
+        contents: undefined,
+        expected: [],
+      },
+      {
+        name: 'empty file',
+        contents: ``,
+        expected: [],
+      },
+      {
+        name: 'regular file',
+        contents: `
+          # This is a comment
+          *.js
+
+          # Ignore php
+          *.php
+        `,
+        expected: ['*.js', '*.php'],
+      },
+      {
+        name: 'included files',
+        contents: `
+          # This is a comment
+          *.js
+
+          # Ignore php
+          *.php
+          #!include: .gitignore
+          /node_modules
+          other_folder/
+        `,
+        extraContents: `
+          .idea
+        `,
+        expected: ['*.js', '*.php', '.idea', '/node_modules', 'other_folder/'],
+      },
+    ];
+
+    beforeEach(async function () {
+      this.dir = pathjoin(tmpdir(), randomFilename());
+      await fs.mkdir(this.dir, { recursive: true });
+    });
+
+    afterEach(async function () {
+      try {
+        await fs.rm(this.dir, { force: true, recursive: true });
+      } catch (err) {
+        if (!errorMessage(err).toUpperCase().includes('ENOENT')) {
+          throw err;
+        }
+      }
+    });
+
+    cases.forEach((tc) => {
+      const runTest = tc.only ? it.only : it;
+      runTest(tc.name, async function () {
+        const pth = randomFilepath(this.dir);
+        if (tc.contents) {
+          await writeSecureFile(pth, tc.contents);
+        }
+
+        if (tc.extraContents) {
+          await writeSecureFile(pathjoin(this.dir, '.gitignore'), tc.extraContents);
+        }
+
+        const result = await parseGcloudIgnore(pth);
+        expect(result).to.eql(tc.expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds logic similar to how gcloud parses gcloud ignores (including parsing nested include files).