### PR TITLE
Add `allowEmptyValues` flag for `parseKVString`

### DIFF
--- a/src/kv.ts
+++ b/src/kv.ts
@@ -46,6 +46,9 @@ export function joinKVString(input: KVPair, separator = ','): string {
  * is trimmed.
  *
  * @param input String with key/value pairs to parse.
+ * @param allowEmptyValues Boolean indicating whether empty values are allowed.
+ *
+ * They will be parsed as empty string ("")
  */
 export function parseKVString(input: string, allowEmptyValues = false): KVPair {
   input = (input || '').trim();

--- a/src/kv.ts
+++ b/src/kv.ts
@@ -47,7 +47,7 @@ export function joinKVString(input: KVPair, separator = ','): string {
  *
  * @param input String with key/value pairs to parse.
  */
-export function parseKVString(input: string): KVPair {
+export function parseKVString(input: string, allowEmptyValues = false): KVPair {
   input = (input || '').trim();
   if (!input) {
     return {};
@@ -79,7 +79,7 @@ export function parseKVString(input: string): KVPair {
       .trim()
       .replace(/\\([,\n])/gi, '$1');
 
-    if (!k || !v) {
+    if (!k || (!v && !allowEmptyValues)) {
       throw new SyntaxError(`Failed to parse KEY=VALUE pair "${pair}": no value`);
     }
 

--- a/tests/kv.test.ts
+++ b/tests/kv.test.ts
@@ -78,6 +78,9 @@ describe('kv', () => {
       only?: boolean;
       name: string;
       input: string;
+      flags?: {
+        allowEmptyValues: boolean;
+      };
       expected?: Record<string, string>;
       error?: string;
     }[] = [
@@ -195,6 +198,12 @@ ftyRyC/83GkAjs88l5eGxNE=
         error: 'Failed to parse',
       },
       {
+        name: 'missing value with allowEmptyValues=true',
+        input: 'FOO=',
+        flags: { allowEmptyValues: true },
+        expected: { FOO: '' },
+      },
+      {
         name: 'no equal',
         input: 'FOO',
         error: 'Failed to parse',
@@ -205,7 +214,11 @@ ftyRyC/83GkAjs88l5eGxNE=
       const fn = tc.only ? it.only : it;
       fn(tc.name, () => {
         if (tc.expected) {
-          expect(parseKVString(tc.input)).to.eql(tc.expected);
+          if (tc.flags) {
+            expect(parseKVString(tc.input, tc.flags.allowEmptyValues)).to.eql(tc.expected);
+          } else {
+            expect(parseKVString(tc.input)).to.eql(tc.expected);
+          }
         } else if (tc.error) {
           expect(() => {
             parseKVString(tc.input);


### PR DESCRIPTION
This simply adds an `allowEmptyValues` flag for the `parseKVString` function, as it is necessary for some cases, such as [labels for resources deployed via GH Actions](https://github.com/google-github-actions/deploy-cloud-functions/issues/392). Currently this use case requires using `labels: 'label1=true'` or similar, when value-less keys are allowed as labels for a resource.

I've updated docs and tests to accommodate for this new value.

This change is fully backwards-compatible thanks to using the default value, and thus typing is inferred too. All tests pass (I can implement extra
