### PR TITLE
Allow custom default values for parseBoolean

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 
-const truths: Record<string, boolean> = {
+const booleanTable: Record<string, boolean> = {
   '1': true,
   't': true,
   'T': true,
   'true': true,
   'True': true,
   'TRUE': true,
+
+  '0': false,
+  'f': false,
+  'F': false,
+  'false': false,
+  'False': false,
+  'FALSE': false,
 };
 
 /**
@@ -30,7 +37,15 @@ const truths: Record<string, boolean> = {
  * @param input The value to check
  * @return boolean
  */
-export function parseBoolean(input?: string): boolean {
-  const trimmed = (input || '').trim();
-  return !!truths[trimmed];
+export function parseBoolean(input?: string, defaultValue: boolean = false): boolean {
+  const key = (input || '').trim();
+  if (key === '') {
+    return defaultValue;
+  }
+
+  if (!(key in booleanTable)) {
+    throw new Error(`invalid boolean value "${key}"`);
+  }
+
+  return booleanTable[key];
 }

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -33,9 +33,26 @@ describe('input', { concurrency: true }, async () => {
         expected: false,
       },
       {
+        name: 'undefined a with custom default',
+        input: undefined,
+        defaultValue: true,
+        expected: true,
+      },
+      {
+        name: 'empty string a with custom default',
+        input: '',
+        defaultValue: true,
+        expected: true,
+      },
+      {
         name: 'nonsense',
         input: '149585',
-        expected: false,
+        error: 'invalid boolean value "149585"',
+      },
+      {
+        name: '1',
+        input: '1',
+        expected: true,
       },
       {
         name: 't',
@@ -63,13 +80,18 @@ describe('input', { concurrency: true }, async () => {
         expected: true,
       },
       {
-        name: '1',
-        input: '1',
-        expected: true,
-      },
-      {
         name: '0',
         input: '0',
+        expected: false,
+      },
+      {
+        name: 'f',
+        input: 'f',
+        expected: false,
+      },
+      {
+        name: 'F',
+        input: 'F',
         expected: false,
       },
       {
@@ -77,12 +99,31 @@ describe('input', { concurrency: true }, async () => {
         input: 'false',
         expected: false,
       },
+      {
+        name: 'False',
+        input: 'False',
+        expected: false,
+      },
+      {
+        name: 'FALSE',
+        input: 'FALSE',
+        expected: false,
+      },
     ];
 
     for await (const tc of cases) {
       await suite.test(tc.name, async () => {
-        const actual = parseBoolean(tc.input);
-        assert.deepStrictEqual(actual, tc.expected);
+        if (tc.error) {
+          assert.throws(
+            () => {
+              parseBoolean(tc.input, tc.defaultValue);
+            },
+            { message: tc.error },
+          );
+        } else {
+          const actual = parseBoolean(tc.input, tc.defaultValue);
+          assert.deepStrictEqual(actual, tc.expected);
+        }
       });
     }
   });


### PR DESCRIPTION
This also changes the behavior to throw an error when an invalid boolean is given (instead of falling back to "false").

Fixes https://github.com/google-github-actions/actions-utils/issues/89